### PR TITLE
Fix for paths with embedded spaces

### DIFF
--- a/src/main/java/hudson/plugin/versioncolumn/JVMVersionComparator.java
+++ b/src/main/java/hudson/plugin/versioncolumn/JVMVersionComparator.java
@@ -137,7 +137,7 @@ class JVMVersionComparator {
         public int get() {
 
             final URL location = Jenkins.class.getProtectionDomain().getCodeSource().getLocation();
-            try (JarFile jarFile = new JarFile(location.getFile())) {
+            try (JarFile jarFile = new JarFile(location.toURI().getPath())) {
                 final ZipEntry jenkinsClassEntry = jarFile.getEntry("jenkins/model/Jenkins.class");
 
                 final InputStream inputStream = jarFile.getInputStream(jenkinsClassEntry);


### PR DESCRIPTION
Resolves FileNotFound exception that was thrown with embedded spaces on a Windows path that were being converted to URL format.   

2022-08-23 11:10:46.361+0000 [id=14]    SEVERE  h.p.v.JVMVersionComparator$MasterBytecodeMajorVersionNumberGetter#get: Issue while reading Jenkins.class bytecode level
java.io.FileNotFoundException: C:\Program%20Files%20(x86)\Jenkins\war\WEB-INF\lib\jenkins-core-2.346.3.jar (The system cannot find the path specified)